### PR TITLE
Add bootstrap_display_state function and improve daemon start logic

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -63,6 +63,38 @@ static std::optional<reed::DisplayState> bootstrap_display_state(
   return state;
 }
 
+static bool apply_display_state(reed::Device& device,
+                                const reed::DisplayState& state) {
+  reed::ScreenConfig screen_config;
+  screen_config.media = state.media;
+  screen_config.ratio = state.ratio;
+  screen_config.screen_mode = state.screen_mode;
+  screen_config.play_mode = state.play_mode;
+
+  return device.set_screen_config(screen_config).has_value() &&
+         device.set_brightness(state.brightness).has_value();
+}
+
+static bool send_keepalive(reed::Device& device, bool verbose) {
+  constexpr int kHandshakeAttempts = 3;
+  constexpr auto kRetryDelay = std::chrono::milliseconds(250);
+
+  for (int attempt = 0; attempt < kHandshakeAttempts; ++attempt) {
+    if (device.handshake()) {
+      return true;
+    }
+
+    if (attempt + 1 < kHandshakeAttempts) {
+      if (verbose) {
+        std::cerr << "Keepalive missed, retrying...\n";
+      }
+      std::this_thread::sleep_for(kRetryDelay);
+    }
+  }
+
+  return false;
+}
+
 static int cmd_info(const std::string& port, bool verbose) {
   reed::Device device(port, verbose);
 
@@ -339,26 +371,49 @@ static int cmd_daemon_start(const std::string& port, bool foreground,
     return 1;
   }
 
-  device.handshake();
+  if (!send_keepalive(device, verbose)) {
+    std::cerr << "Failed to initialize device keepalive\n";
+    return 1;
+  }
 
-  reed::ScreenConfig screen_config;
-  screen_config.media = state->media;
-  screen_config.ratio = state->ratio;
-  screen_config.screen_mode = state->screen_mode;
-  screen_config.play_mode = state->play_mode;
-
-  device.set_screen_config(screen_config);
-  device.set_brightness(state->brightness);
+  if (!apply_display_state(device, *state)) {
+    std::cerr << "Failed to restore display state\n";
+    return 1;
+  }
 
   std::cout << "Display restored. Running keepalive...\n";
 
   std::signal(SIGINT, signal_handler);
   std::signal(SIGTERM, signal_handler);
 
+  auto next_keepalive =
+      std::chrono::steady_clock::now() + std::chrono::seconds(keepalive_interval);
+
   while (g_running) {
-    std::this_thread::sleep_for(std::chrono::seconds(keepalive_interval));
+    auto now = std::chrono::steady_clock::now();
+    if (next_keepalive > now) {
+      std::this_thread::sleep_for(next_keepalive - now);
+    }
+
     if (!g_running) break;
-    device.handshake();
+
+    now = std::chrono::steady_clock::now();
+
+    if (now >= next_keepalive) {
+      next_keepalive = now + std::chrono::seconds(keepalive_interval);
+
+      if (!send_keepalive(device, verbose)) {
+        if (verbose) {
+          std::cerr << "Keepalive failed, reconnecting display...\n";
+        }
+
+        device.disconnect();
+        if (!device.connect() || !send_keepalive(device, verbose) ||
+            !apply_display_state(device, *state)) {
+          continue;
+        }
+      }
+    }
   }
 
   return 0;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -45,6 +45,24 @@ static void print_usage(const char* prog) {
          "  --foreground            Run daemon in foreground\n";
 }
 
+static std::optional<reed::DisplayState> bootstrap_display_state(
+    int brightness) {
+  auto media = reed::Adb::list_media();
+  if (!media) {
+    return std::nullopt;
+  }
+
+  reed::DisplayState state;
+  state.media = *media;
+  state.brightness = brightness;
+
+  if (!reed::ConfigManager::save_state(state)) {
+    return std::nullopt;
+  }
+
+  return state;
+}
+
 static int cmd_info(const std::string& port, bool verbose) {
   reed::Device device(port, verbose);
 
@@ -295,14 +313,22 @@ static int cmd_daemon_start(const std::string& port, bool foreground,
   }
 
   // Foreground daemon mode
+  auto config = reed::ConfigManager::load_config();
+  int default_brightness = config ? config->brightness : 75;
+
   auto state = reed::ConfigManager::load_state();
   if (!state || state->media.empty()) {
-    std::cerr
-        << "No display state saved. Run 'reed-tpse display <file>' first.\n";
-    return 1;
+    state = bootstrap_display_state(default_brightness);
+    if (!state) {
+      std::cerr << "Failed to load or save display state.\n";
+      return 1;
+    }
   }
 
-  auto config = reed::ConfigManager::load_config();
+  if (state->media.empty()) {
+    return 0;
+  }
+
   std::string actual_port =
       (config && !config->port.empty()) ? config->port : port;
   int keepalive_interval = config ? config->keepalive_interval : 10;

--- a/src/adb.cpp
+++ b/src/adb.cpp
@@ -13,6 +13,22 @@ struct PipeCloser {
     if (f) pclose(f);
   }
 };
+
+std::optional<std::string> run_shell_command(const std::string& command) {
+  std::array<char, 4096> buffer;
+  std::string result;
+
+  std::unique_ptr<FILE, PipeCloser> pipe(popen(command.c_str(), "r"));
+  if (!pipe) {
+    return std::nullopt;
+  }
+
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    result += buffer.data();
+  }
+
+  return result;
+}
 }  // namespace
 
 std::optional<std::string> Adb::run_command(
@@ -38,19 +54,7 @@ std::optional<std::string> Adb::run_command(
   }
   cmd += " 2>&1";
 
-  std::array<char, 4096> buffer;
-  std::string result;
-
-  std::unique_ptr<FILE, PipeCloser> pipe(popen(cmd.c_str(), "r"));
-  if (!pipe) {
-    return std::nullopt;
-  }
-
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    result += buffer.data();
-  }
-
-  return result;
+  return run_shell_command(cmd);
 }
 
 bool Adb::is_device_connected() {


### PR DESCRIPTION

sometimes, when services starts getting these error because no state file

```
journalctl --user -u reed-tpse.service -n 80 --no-pager
May 26 22:09:00 Shawn systemd[16296]: reed-tpse.service: Scheduled restart job, restart counter is at 1.
May 26 22:09:00 Shawn systemd[16296]: Started reed-tpse.service - Tryx Panorama SE AIO Display Controller for Linux Distros.
May 26 22:09:01 Shawn reed-tpse[146031]: Found device at /dev/ttyACM0
May 26 22:09:01 Shawn reed-tpse[146031]: No display state saved. Run 'reed-tpse display <file>' first.
May 26 22:09:01 Shawn systemd[16296]: reed-tpse.service: Main process exited, code=exited, status=1/FAILURE
May 26 22:09:01 Shawn systemd[16296]: reed-tpse.service: Failed with result 'exit-code'.
May 26 22:09:06 Shawn systemd[16296]: reed-tpse.service: Scheduled restart job, restart counter is at 2.
May 26 22:09:06 Shawn systemd[16296]: Started reed-tpse.service - Tryx Panorama SE AIO Display Controller for Linux Distros.
May 26 22:09:06 Shawn reed-tpse[146077]: Found device at /dev/ttyACM0
May 26 22:09:06 Shawn reed-tpse[146077]: No display state saved. Run 'reed-tpse display <file>' first.
May 26 22:09:06 Shawn systemd[16296]: reed-tpse.service: Main process exited, code=exited, status=1/FAILURE
May 26 22:09:06 Shawn systemd[16296]: reed-tpse.service: Failed with result 'exit-code'.
```

adding mechanism to automatically save display state


automatically saved state file

```
cat ~/.local/state/reed-tpse/display.json
{"brightness":75,"media":["2026-02-01_00-40-48-889.mp4","2026-02-01_00-41-14-428.mp4","2026-02-01_00-42-12-983.mp4","2026-02-01_00-43-23-693.mp4","2026-02-01_00-44-04-514.mp4","2026-02-01_01-27-13-971.mp4","2026-02-01_01-35-03-050.mp4","2026-02-01_01-37-07-139.mp4","2026-02-01_01-37-31-679.mp4","2026-02-01_01-37-44-291.mp4","2026-05-22_08-55-33-570.mp4","2026-05-22_08-58-13-129.mp4","2026-05-22_08-58-46-764.mp4","2026-05-22_08-59-49-380.mp4","2026-05-22_09-00-51-193.mp4","2026-05-22_09-01-25-943.mp4","2026-05-22_09-02-15-940.mp4","2026-05-22_09-05-07-892.mp4","naganadel.mp4"],"play_mode":"Single","ratio":"2:1","screen_mode":"Full Screen"}
```

since there are many videos, play mode can change to Shuffle
